### PR TITLE
Add dashboard page for +1 pip comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# Руководство по проекту 1pips
+
+## Назначение
+Проект автоматизирует сравнение базового стоп-лосса и стоп-лосса, расширенного на +1 пипс, на основе тиковых данных. Он включает:
+
+* инструменты для подготовки тиковых CSV (TrueFX и собственные выгрузки);
+* симулятор `one_pip_stop_sensitivity.py`, который воспроизводит сделки SMC-адаптера и сравнивает итоговый win-rate;
+* статичный дашборд в папке `site/`, который визуализирует результаты последнего запуска.
+
+## Зависимости
+* Python 3.9+
+* [pandas](https://pandas.pydata.org/)
+* [numpy](https://numpy.org/)
+* [tqdm](https://tqdm.github.io/)
+* библиотека [`smartmoneyconcepts`](https://pypi.org/project/smartmoneyconcepts/) и локальный адаптер `smc_adapter_josh.py`
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install pandas numpy tqdm smartmoneyconcepts
+```
+
+## Подготовка данных
+### 1. Конвертация выгрузки TrueFX
+TrueFX предоставляет CSV вида `EUR/USD,20250701 00:00:00.953,1.17862,1.17866`.
+
+```bash
+python convert_truefx.py EURUSD-2025-09.csv
+```
+
+Скрипт создаст файл `EURUSD-2025-09_converted.csv` c колонками `time,bid,ask` и корректной таймзоной.
+
+### 2. Конвертация собственного CSV
+Если у вас уже есть CSV `time,bid,ask`, при необходимости сформируйте минутные свечи:
+
+```bash
+python convert_ticks.py
+```
+
+Скрипт читает `ticks.csv`, агрегирует mid-цену до минутных OHLC и сохраняет результат в `candles_1m.csv`.
+
+## Запуск симулятора
+Основной сценарий — `one_pip_stop_sensitivity.py`.
+
+```bash
+python one_pip_stop_sensitivity.py \
+  --csv EURUSD-2025-09_converted.csv \
+  --pip-size 0.0001 \
+  --smc-swing-lookback 50 \
+  --retest-tolerance-pips 0.2 \
+  --tp-mode structure \
+  --min-rr 1.0 \
+  --min-sl-pips 1.0 \
+  --min-tp-pips 1.0
+```
+
+Ключевые параметры:
+
+* `--pip-size` — размер пипса для инструмента (EURUSD = 0.0001, XAUUSD = 0.1 и т.д.).
+* `--tp-mode structure|symmetric` — использовать тейк-профит адаптера или симметричный тейк с заданным RR.
+* `--min-rr`, `--min-sl-pips`, `--min-tp-pips` — фильтры по R/R, риску и вознаграждению в пипсах.
+* Параметры `--smc-sessions`, `--smc-fvg`, `--tf` оставлены для совместимости со старыми пайплайнами.
+
+### Выходные файлы
+После завершения симулятор сохранит:
+
+* `one_pip_results_detailed.csv` — подробный список сделок (entry time, цены, исходы базового и +1 пипс стопов).
+* `site/data/one_pip_summary.json` — агрегированные метрики (win-rate, McNemar, фильтры, разбивка по направлению).
+* `smc_lib_debug.csv` — журнал причин, по которым адаптер мог отбраковать сделки.
+
+## Обновление и просмотр дашборда
+Дашборд в `site/` читает `site/data/one_pip_summary.json`. Чтобы посмотреть обновлённые результаты:
+
+```bash
+cd site
+python -m http.server 8000
+```
+
+Откройте в браузере `http://localhost:8000` — страница отобразит win-rate базового стопа и стопа с добавленным пипсом, параметры фильтрации и разбивку по направлениям.
+
+## Советы по воспроизведению
+* Убедитесь, что `smc_adapter_josh.py` соответствует версии `smartmoneyconcepts`, используемой в проекте.
+* Если симулятор сообщает, что все сделки отфильтрованы, попробуйте снизить `--min-rr` или переключиться на `--tp-mode symmetric`.
+* Для обработки больших CSV используйте SSD и достаточно свободной памяти; `convert_truefx.py` уже записывает результат чанками, чтобы снизить нагрузку.

--- a/convert_truefx.py
+++ b/convert_truefx.py
@@ -15,14 +15,31 @@ outfile = infile.replace(".csv", "_converted.csv")
 print(f"Converting {infile} -> {outfile}")
 
 # читаем truefx: EUR/USD,20250701 00:00:00.953,1.17862,1.17866
-# используем tqdm для прогресса по чанкам
+# используем tqdm для прогресса по чанкам и сразу пишем результат,
+# чтобы не держать все данные в памяти
 chunksize = 300000
-dfs = []
-for chunk in tqdm(pd.read_csv(infile, header=None, names=["pair","time_raw","bid","ask"], chunksize=chunksize), desc="Processing"):
-    chunk["time"] = pd.to_datetime(chunk["time_raw"], format="%Y%m%d %H:%M:%S.%f", utc=True)
-    dfs.append(chunk[["time","bid","ask"]])
+reader = pd.read_csv(
+    infile,
+    header=None,
+    names=["pair", "time_raw", "bid", "ask"],
+    chunksize=chunksize,
+)
 
-df_out = pd.concat(dfs, ignore_index=True)
-df_out.to_csv(outfile, index=False)
+first_chunk = True
+for chunk in tqdm(reader, desc="Processing"):
+    chunk["time"] = pd.to_datetime(
+        chunk["time_raw"],
+        format="%Y%m%d %H:%M:%S.%f",
+        utc=True,
+        errors="coerce",
+    )
+    converted = chunk[["time", "bid", "ask"]].dropna(subset=["time"])
+    converted.to_csv(
+        outfile,
+        mode="w" if first_chunk else "a",
+        header=first_chunk,
+        index=False,
+    )
+    first_chunk = False
 
 print(f"Done! Saved to {outfile}")

--- a/one_pip_stop_sensitivity.py
+++ b/one_pip_stop_sensitivity.py
@@ -22,8 +22,11 @@ Pipeline:
 Requires: pandas, tqdm, smartmoneyconcepts; local smc_adapter_josh.py
 """
 import argparse
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List, Dict, Any, Tuple
+import numpy as np
 import pandas as pd
 from tqdm import tqdm
 from smc_adapter_josh import generate_entries_with_josh
@@ -50,7 +53,8 @@ def mcnemar_exact(b: int, c: int) -> float:
 
 
 def simulate_until_exit(
-    ticks: pd.DataFrame,
+    bids: np.ndarray,
+    asks: np.ndarray,
     entry_idx: int,
     direction: int,
     stop_price: float,
@@ -59,22 +63,34 @@ def simulate_until_exit(
     """
     Long: exit on BID (TP if bid>=tp, SL if bid<=sl)
     Short: exit on ASK (TP if ask<=tp, SL if ask>=sl)
+    Returns True if TP is hit before SL, False otherwise.
     """
     if direction not in (+1, -1):
         raise ValueError("direction must be +1 or -1")
-    if entry_idx < 0 or entry_idx >= len(ticks) - 1:
+
+    start = entry_idx + 1
+    if start >= len(bids):
         return False
 
-    for i in range(entry_idx + 1, len(ticks)):
-        bid = ticks.iloc[i]["bid"]
-        ask = ticks.iloc[i]["ask"]
-        if direction == +1:
-            if bid >= tp_price: return True
-            if bid <= stop_price: return False
-        else:
-            if ask <= tp_price: return True
-            if ask >= stop_price: return False
-    return False  # open at EOF -> count as loss
+    if direction == +1:
+        bid_slice = bids[start:]
+        tp_hits = np.flatnonzero(bid_slice >= tp_price)
+        sl_hits = np.flatnonzero(bid_slice <= stop_price)
+    else:
+        ask_slice = asks[start:]
+        tp_hits = np.flatnonzero(ask_slice <= tp_price)
+        sl_hits = np.flatnonzero(ask_slice >= stop_price)
+
+    tp_idx = tp_hits[0] if tp_hits.size else None
+    sl_idx = sl_hits[0] if sl_hits.size else None
+
+    if tp_idx is None and sl_idx is None:
+        return False  # open at EOF -> count as loss
+    if tp_idx is None:
+        return False
+    if sl_idx is None:
+        return True
+    return tp_idx <= sl_idx
 
 
 def load_ticks(path: str) -> pd.DataFrame:
@@ -105,10 +121,18 @@ def main():
                     help="Disable CHOCH; BOS only")
     ap.add_argument("--min-rr", type=float, default=1.0,
                     help="Minimum R/R (reward/risk). 1.0 = drop RR<1:1. 0.0 = disable filter.")
+    ap.add_argument("--min-sl-pips", type=float, default=0.0,
+                    help="Drop trades where risk (entry->SL) is below this value in pips.")
+    ap.add_argument("--min-tp-pips", type=float, default=0.0,
+                    help="Drop trades where reward (entry->TP) is below this value in pips.")
     ap.add_argument("--tp-mode", type=str, default="structure",
                     choices=["structure", "symmetric"],
                     help="TP mode: 'structure' (adapter TP) or 'symmetric' (TP at min_rr*risk).")
     ap.add_argument("--tf", type=int, default=1, help="Unused (CLI compatibility)")
+    ap.add_argument("--smc-sessions", type=str, default="on",
+                    help="SMC session filter (CLI compatibility; currently informational only).")
+    ap.add_argument("--smc-fvg", type=float, default=0.0,
+                    help="Fair value gap filter (CLI compatibility; currently informational only).")
 
     args = ap.parse_args()
     if args.allow_choch_fallback and args.no_choch_fallback:
@@ -116,9 +140,15 @@ def main():
 
     pip = float(args.pip_size)
     min_rr = max(0.0, float(args.min_rr))
+    min_sl_pips = max(0.0, float(args.min_sl_pips))
+    min_tp_pips = max(0.0, float(args.min_tp_pips))
     tp_mode = args.tp_mode
 
     ticks = load_ticks(args.csv)
+
+    bid_arr = ticks["bid"].to_numpy(dtype=float)
+    ask_arr = ticks["ask"].to_numpy(dtype=float)
+    time_arr = ticks["time"].to_numpy()
 
     # 1) Entries from adapter (structure-based SL/TP)
     entries_raw = generate_entries_with_josh(
@@ -143,9 +173,11 @@ def main():
     # (Entry, entry_price, risk_pips, reward_pips, rr_used, stop_price_used, tp_price_used)
 
     dropped_rr = 0
+    dropped_sl = 0
+    dropped_tp = 0
     for e in entries:
         # entry side price
-        entry_side_price = ticks.iloc[e.tick_idx]["ask"] if e.direction == +1 else ticks.iloc[e.tick_idx]["bid"]
+        entry_side_price = float(ask_arr[e.tick_idx] if e.direction == +1 else bid_arr[e.tick_idx])
 
         # risk (pips) from entry to SL
         if e.direction == +1:
@@ -153,11 +185,18 @@ def main():
         else:
             risk_pips = max(0.0, (e.stop_price - entry_side_price) / pip)
 
+        if risk_pips + 1e-12 < min_sl_pips:
+            dropped_sl += 1
+            continue
+
         # Choose TP
         if tp_mode == "structure":
             tp_price_used = e.tp_price
             reward_pips = max(0.0, (tp_price_used - entry_side_price) / pip) if e.direction == +1 \
                           else max(0.0, (entry_side_price - tp_price_used) / pip)
+            if reward_pips + 1e-12 < min_tp_pips:
+                dropped_tp += 1
+                continue
             rr = (float("inf") if risk_pips == 0 and reward_pips > 0
                   else (0.0 if risk_pips == 0 else reward_pips / risk_pips))
             # RR filter
@@ -167,6 +206,9 @@ def main():
         else:  # symmetric
             # Set reward to at least min_rr * risk
             target_reward_pips = min_rr * risk_pips
+            if target_reward_pips + 1e-12 < min_tp_pips:
+                dropped_tp += 1
+                continue
             if e.direction == +1:
                 tp_price_used = entry_side_price + target_reward_pips * pip
             else:
@@ -185,37 +227,52 @@ def main():
 
     if dropped_rr > 0 and tp_mode == "structure":
         print(f"Filtered out by RR < {min_rr}: {dropped_rr} trades (kept {len(prepared)}).")
+    if dropped_sl > 0:
+        print(f"Filtered out by risk < {min_sl_pips} pips: {dropped_sl} trades.")
+    if dropped_tp > 0:
+        print(f"Filtered out by reward < {min_tp_pips} pips: {dropped_tp} trades.")
 
     # 3) Simulate outcomes
     base_wins = plus_wins = 0
     b = c = 0
     rows: List[Dict[str, Any]] = []
+    direction_totals = {
+        +1: {"trades": 0, "base_wins": 0, "plus1_wins": 0},
+        -1: {"trades": 0, "base_wins": 0, "plus1_wins": 0},
+    }
 
     for idx, (e, entry_price, risk_pips, reward_pips, rr_used, stop_price_used, tp_price_used) in enumerate(
         tqdm(prepared, desc="Simulating", unit="trade")
     ):
         # entry time string
-        entry_ts = ticks.iloc[e.tick_idx]["time"]
-        try:
-            entry_time_str = entry_ts.isoformat()
-        except AttributeError:
-            entry_time_str = str(entry_ts)
+        entry_ts = pd.Timestamp(time_arr[e.tick_idx])
+        entry_time_str = entry_ts.isoformat() if not pd.isna(entry_ts) else ""
 
         # Base outcome (chosen TP mode)
         base_win = simulate_until_exit(
-            ticks, e.tick_idx, e.direction, stop_price_used, tp_price_used
+            bid_arr, ask_arr, e.tick_idx, e.direction, stop_price_used, tp_price_used
         )
 
         # +1 pip stop (same TP)
         stop_plus = stop_price_used - pip if e.direction == +1 else stop_price_used + pip
         plus_win = simulate_until_exit(
-            ticks, e.tick_idx, e.direction, stop_plus, tp_price_used
+            bid_arr, ask_arr, e.tick_idx, e.direction, stop_plus, tp_price_used
         )
 
-        base_wins += int(base_win)
-        plus_wins += int(plus_win)
+        base_win_int = int(base_win)
+        plus_win_int = int(plus_win)
+
+        base_wins += base_win_int
+        plus_wins += plus_win_int
         if base_win and not plus_win: b += 1
         elif (not base_win) and plus_win: c += 1
+
+        if e.direction not in direction_totals:
+            direction_totals[e.direction] = {"trades": 0, "base_wins": 0, "plus1_wins": 0}
+        dir_bucket = direction_totals[e.direction]
+        dir_bucket["trades"] += 1
+        dir_bucket["base_wins"] += base_win_int
+        dir_bucket["plus1_wins"] += plus_win_int
 
         rows.append({
             "trade_id": idx,
@@ -253,8 +310,65 @@ def main():
     print(f"mcnemar_c (base lose, plus win): {c}")
     print(f"mcnemar_exact_p: {pval:.6f}")
 
-    pd.DataFrame(rows).to_csv("one_pip_results_detailed.csv", index=False)
+    detailed_df = pd.DataFrame(rows)
+    detailed_df.to_csv("one_pip_results_detailed.csv", index=False)
     print("Detailed results saved to: one_pip_results_detailed.csv")
+
+    # 5) Summary export for website / dashboards
+    long_bucket = direction_totals.get(+1, {"trades": 0, "base_wins": 0, "plus1_wins": 0})
+    short_bucket = direction_totals.get(-1, {"trades": 0, "base_wins": 0, "plus1_wins": 0})
+
+    def bucket_wr(bucket: Dict[str, Any]) -> Tuple[Any, Any]:
+        trades = bucket.get("trades", 0)
+        if not trades:
+            return None, None
+        return bucket["base_wins"] / trades, bucket["plus1_wins"] / trades
+
+    long_base_wr, long_plus_wr = bucket_wr(long_bucket)
+    short_base_wr, short_plus_wr = bucket_wr(short_bucket)
+
+    summary = {
+        "trades_kept": total,
+        "base": {
+            "wins": int(base_wins),
+            "win_rate": base_wr,
+        },
+        "plus1": {
+            "wins": int(plus_wins),
+            "win_rate": plus_wr,
+        },
+        "delta_win_rate": delta_wr,
+        "mcnemar": {
+            "b": int(b),
+            "c": int(c),
+            "p_value": pval,
+        },
+        "filters": {
+            "min_rr": min_rr,
+            "min_sl_pips": min_sl_pips,
+            "min_tp_pips": min_tp_pips,
+            "tp_mode": tp_mode,
+        },
+        "direction_breakdown": {
+            "long": {
+                "trades": long_bucket.get("trades", 0),
+                "base_win_rate": long_base_wr,
+                "plus1_win_rate": long_plus_wr,
+            },
+            "short": {
+                "trades": short_bucket.get("trades", 0),
+                "base_win_rate": short_base_wr,
+                "plus1_win_rate": short_plus_wr,
+            },
+        },
+    }
+
+    site_data_dir = Path("site/data")
+    site_data_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = site_data_dir / "one_pip_summary.json"
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"Summary saved to: {summary_path}")
+
     print("Adapter debug (reasons) saved to: smc_lib_debug.csv")
 
 

--- a/site/data/one_pip_summary.json
+++ b/site/data/one_pip_summary.json
@@ -1,0 +1,35 @@
+{
+  "trades_kept": 99,
+  "base": {
+    "wins": 36,
+    "win_rate": 0.36363636363636365
+  },
+  "plus1": {
+    "wins": 38,
+    "win_rate": 0.3838383838383838
+  },
+  "delta_win_rate": 0.020202020202020204,
+  "mcnemar": {
+    "b": 0,
+    "c": 2,
+    "p_value": 0.5
+  },
+  "filters": {
+    "min_rr": null,
+    "min_sl_pips": null,
+    "min_tp_pips": null,
+    "tp_mode": null
+  },
+  "direction_breakdown": {
+    "long": {
+      "trades": 53,
+      "base_win_rate": 0.32075471698113206,
+      "plus1_win_rate": 0.33962264150943394
+    },
+    "short": {
+      "trades": 46,
+      "base_win_rate": 0.41304347826086957,
+      "plus1_win_rate": 0.43478260869565216
+    }
+  }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>One Pip Stop Sensitivity Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Сравнение базового стопа и стопа +1 пипс</h1>
+      <p class="note">Данные обновляются после запуска симулятора <code>one_pip_stop_sensitivity.py</code>.</p>
+    </header>
+
+    <section id="overview" class="card">
+      <h2>Итоги симуляции</h2>
+      <div class="grid">
+        <div class="stat">
+          <span class="label">Трейдов после фильтров</span>
+          <span class="value" id="trades-kept">—</span>
+        </div>
+        <div class="stat">
+          <span class="label">Win-rate (база)</span>
+          <span class="value" id="base-wr">—</span>
+        </div>
+        <div class="stat">
+          <span class="label">Win-rate (+1 пипс)</span>
+          <span class="value" id="plus-wr">—</span>
+        </div>
+        <div class="stat">
+          <span class="label">Δ win-rate</span>
+          <span class="value" id="delta-wr">—</span>
+        </div>
+        <div class="stat">
+          <span class="label">McNemar p-value</span>
+          <span class="value" id="p-value">—</span>
+        </div>
+      </div>
+    </section>
+
+    <section id="filters" class="card">
+      <h2>Параметры фильтров</h2>
+      <table>
+        <tbody>
+          <tr><th>Min RR</th><td id="min-rr">—</td></tr>
+          <tr><th>Min SL (пипсов)</th><td id="min-sl">—</td></tr>
+          <tr><th>Min TP (пипсов)</th><td id="min-tp">—</td></tr>
+          <tr><th>TP режим</th><td id="tp-mode">—</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="direction" class="card">
+      <h2>Разбивка по направлению</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Направление</th>
+            <th>Сделок</th>
+            <th>Win-rate (база)</th>
+            <th>Win-rate (+1 пипс)</th>
+          </tr>
+        </thead>
+        <tbody id="direction-body">
+          <tr><td colspan="4" class="empty">Нет данных</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card" id="data-status">
+      <h2>Статус данных</h2>
+      <p id="status-message">Загрузка...</p>
+    </section>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/site/script.js
+++ b/site/script.js
@@ -1,0 +1,81 @@
+const formatPct = (value) =>
+  typeof value === "number" && Number.isFinite(value)
+    ? `${(value * 100).toFixed(2)}%`
+    : "—";
+
+const setText = (id, text) => {
+  const el = document.getElementById(id);
+  if (el) {
+    el.textContent = text;
+  }
+};
+
+const updateDirectionTable = (breakdown = {}) => {
+  const tbody = document.getElementById("direction-body");
+  if (!tbody) return;
+
+  const entries = [
+    ["Лонг", breakdown.long],
+    ["Шорт", breakdown.short],
+  ];
+
+  const hasData = entries.some(([, data]) => data && data.trades);
+  if (!hasData) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">Нет данных</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = "";
+  for (const [label, data] of entries) {
+    const row = document.createElement("tr");
+    if (!data || !data.trades) {
+      row.innerHTML = `<td>${label}</td><td>0</td><td>—</td><td>—</td>`;
+    } else {
+      row.innerHTML = `
+        <td>${label}</td>
+        <td>${data.trades}</td>
+        <td>${formatPct(data.base_win_rate)}</td>
+        <td>${formatPct(data.plus1_win_rate)}</td>
+      `;
+    }
+    tbody.appendChild(row);
+  }
+};
+
+const showStatus = (message, isError = false) => {
+  const statusCard = document.getElementById("data-status");
+  const statusMessage = document.getElementById("status-message");
+  if (!statusCard || !statusMessage) return;
+  statusCard.style.display = "block";
+  statusMessage.textContent = message;
+  statusMessage.className = isError ? "error" : "";
+};
+
+fetch("data/one_pip_summary.json", { cache: "no-cache" })
+  .then((response) => {
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return response.json();
+  })
+  .then((summary) => {
+    setText("trades-kept", summary.trades_kept ?? "—");
+    setText("base-wr", formatPct(summary.base?.win_rate));
+    setText("plus-wr", formatPct(summary.plus1?.win_rate));
+    setText("delta-wr", formatPct(summary.delta_win_rate));
+    setText("p-value", summary.mcnemar?.p_value?.toFixed(6) ?? "—");
+
+    const filters = summary.filters ?? {};
+    setText("min-rr", filters.min_rr ?? "—");
+    setText("min-sl", filters.min_sl_pips ?? "—");
+    setText("min-tp", filters.min_tp_pips ?? "—");
+    setText("tp-mode", filters.tp_mode ?? "—");
+
+    updateDirectionTable(summary.direction_breakdown);
+
+    showStatus("Данные успешно загружены.");
+  })
+  .catch((error) => {
+    console.error(error);
+    showStatus("Не удалось загрузить данные. Запустите симулятор, чтобы обновить файл.", true);
+  });

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,117 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1rem;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.2), transparent 55%),
+    radial-gradient(circle at bottom, rgba(14, 165, 233, 0.15), transparent 65%),
+    #020617;
+}
+
+main {
+  width: min(960px, 100%);
+  display: grid;
+  gap: 1.5rem;
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 1.2rem + 2vw, 2.6rem);
+}
+
+.note {
+  margin-top: 0.4rem;
+  color: #94a3b8;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.02em;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stat {
+  background: rgba(30, 41, 59, 0.7);
+  padding: 1rem;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.stat .label {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.stat .value {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+th,
+td {
+  padding: 0.6rem 0.8rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+th {
+  color: #cbd5f5;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.empty {
+  text-align: center;
+  color: #64748b;
+}
+
+#data-status {
+  display: none;
+}
+
+.error {
+  color: #f87171;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 2rem 0.5rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- export simulator win-rate metrics to site/data/one_pip_summary.json for downstream use
- add a static dashboard that reads the JSON and visualises base vs +1 pip performance and filters

## Testing
- `python -m compileall convert_truefx.py one_pip_stop_sensitivity.py smc_adapter_josh.py`


------
https://chatgpt.com/codex/tasks/task_e_68e04365b30c83288b74e082ba75cc6c