### PR TITLE
Refine smart money concepts integration with order-block retests

### DIFF
--- a/one_pip_stop_sensitivity.py
+++ b/one_pip_stop_sensitivity.py
@@ -8,8 +8,8 @@ Pipeline:
 2) Adapter (smc_adapter_josh.generate_entries_with_josh):
    - ticks -> M1,
    - BOS/CHOCH by smartmoneyconcepts,
-   - first retest -> entry,
-   - SL behind opposite minute swing; TP behind structural swing (adapter outputs).
+   - retest of SMC order-block with optional FVG confirmation -> entry,
+   - SL behind liquidity swing/order-block; TP behind structural swing (adapter outputs).
 3) Choose TP mode:
    - structure: use adapter TP (may yield RR<1).
    - symmetric: set TP at min_rr * risk from entry (guarantee RR>=min_rr).
@@ -95,10 +95,14 @@ def main():
                     help="swing_length for SMC swings (default=50)")
     ap.add_argument("--retest-tolerance-pips", type=float, default=0.2,
                     help="Retest touch tolerance in pips")
+    ap.add_argument("--max-retest-minutes", type=int, default=360,
+                    help="Maximum minutes to wait for an order-block retest")
     ap.add_argument("--sl-beyond-swing-pips", type=float, default=0.0,
                     help="Extra SL beyond swing in pips")
     ap.add_argument("--tp-beyond-swing-pips", type=float, default=0.0,
                     help="Extra TP beyond swing in pips (structure mode)")
+    ap.add_argument("--no-fvg-confirmation", action="store_true",
+                    help="Disable FVG confirmation filter for entries")
     ap.add_argument("--allow-choch-fallback", action="store_true",
                     help="Allow CHOCH if no BOS on the bar")
     ap.add_argument("--no-choch-fallback", action="store_true",
@@ -130,6 +134,8 @@ def main():
         retest_tolerance_pips=float(args.retest_tolerance_pips),
         sl_margin_pips=float(args.sl_beyond_swing_pips),
         tp_margin_pips=float(args.tp_beyond_swing_pips),
+        require_fvg_confirmation=(not args.no_fvg_confirmation),
+        max_retest_minutes=int(args.max_retest_minutes),
         debug_log_path="smc_lib_debug.csv",
     )
     if not entries_raw:

--- a/smc_adapter_josh.py
+++ b/smc_adapter_josh.py
@@ -181,7 +181,10 @@ def generate_entries_with_josh(
     col_fvg_mitigated = _col(fvgs, "MitigatedIndex")
 
     # 5) подготовка утилит
-    base_times = df_ticks["time"].to_numpy()
+    # Работать с tz-aware Timestamp напрямую в numpy непросто: searchsorted
+    # пытается сравнивать tz-aware и tz-naive представления и падает.
+    # Поэтому приводим времена к числу наносекунд от эпохи (UTC).
+    base_times = df_ticks["time"].apply(lambda x: x.value).to_numpy()
     tol = float(retest_tolerance_pips) * float(pip)
     max_retest_bars = max(1, int(max_retest_minutes))
 
@@ -191,8 +194,10 @@ def generate_entries_with_josh(
             end_ts = pd.to_datetime(m1.loc[minute_idx + 1, "time"], utc=True)
         else:
             end_ts = start_ts + pd.Timedelta(minutes=1)
-        start = int(np.searchsorted(base_times, start_ts.to_datetime64()))
-        end = int(np.searchsorted(base_times, end_ts.to_datetime64(), side="left"))
+        start_val = start_ts.value
+        end_val = end_ts.value
+        start = int(np.searchsorted(base_times, start_val))
+        end = int(np.searchsorted(base_times, end_val, side="left"))
         if start >= len(base_times):
             start = len(base_times) - 1
         start = max(0, start)

--- a/smc_adapter_josh.py
+++ b/smc_adapter_josh.py
@@ -1,6 +1,7 @@
 # smc_adapter_josh.py
 # -*- coding: utf-8 -*-
 from typing import List, Tuple, Dict, Any, Optional
+from bisect import bisect_right
 import pandas as pd
 import numpy as np
 from pathlib import Path
@@ -31,14 +32,23 @@ def _ticks_to_m1(ticks: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
     df = df.dropna(subset=["time","bid","ask"]).sort_values("time").reset_index(drop=True)
 
     mid = (df["bid"] + df["ask"]) / 2.0
-    m1 = (
+    grouped = (
         pd.DataFrame({"time": df["time"], "mid": mid})
         .set_index("time")
         .resample("1min")
-        .agg(["first","max","min","last"])
-        .dropna()
     )
-    m1.columns = ["open","high","low","close"]
+
+    m1 = grouped.agg(["first", "max", "min", "last"]).dropna()
+    m1.columns = ["open", "high", "low", "close"]
+
+    volume = (
+        pd.DataFrame({"time": df["time"], "vol": 1.0})
+        .set_index("time")
+        .resample("1min")
+        .sum()
+    )
+
+    m1 = m1.join(volume, how="left").rename(columns={"vol": "volume"}).fillna({"volume": 0.0})
     m1 = m1.reset_index(drop=False)
     return df, m1
 
@@ -51,8 +61,23 @@ def _dbg_init(path: Optional[str]) -> Optional[Path]:
     if write_header:
         with p.open("w", newline="") as f:
             w = csv.writer(f)
-            w.writerow(["reason","i","entry_min_idx","dir","entry_time","hour",
-                        "level","tol_pips","sl_pips","tp_pips"])
+            w.writerow([
+                "reason",
+                "i",
+                "entry_min_idx",
+                "dir",
+                "entry_time",
+                "hour",
+                "level",
+                "tol_pips",
+                "sl_pips",
+                "tp_pips",
+                "ob_idx",
+                "fvg_idx",
+                "ob_top",
+                "ob_bottom",
+                "target_level",
+            ])
     return p
 
 def _dbg_row(p: Optional[Path], **kw) -> None:
@@ -71,6 +96,11 @@ def _dbg_row(p: Optional[Path], **kw) -> None:
             kw.get("tol_pips"),
             kw.get("sl_pips"),
             kw.get("tp_pips"),
+            kw.get("ob_idx"),
+            kw.get("fvg_idx"),
+            kw.get("ob_top"),
+            kw.get("ob_bottom"),
+            kw.get("target_level"),
         ])
 
 def _col(df: pd.DataFrame, *names: str) -> Optional[str]:
@@ -92,14 +122,17 @@ def generate_entries_with_josh(
     retest_tolerance_pips: float = 0.2,
     sl_margin_pips: float = 0.0,
     tp_margin_pips: float = 0.0,
+    require_fvg_confirmation: bool = True,
+    max_retest_minutes: int = 360,
     debug_log_path: Optional[str] = "smc_lib_debug.csv",
 ) -> List[Entry]:
     """
     Чистая связка под API smartmoneyconcepts (README):
       - swing_highs_lows(ohlc, swing_length)
       - bos_choch(ohlc, swing_highs_lows, close_break=True)
-    Сигналы читаем из колонок BOS/CHOCH, уровень ретеста — из Level.
-    SL/TP — за ближайшими минутными свингами (HighLow = ±1).
+      - ob(...) + fvg(...) для подтверждения ликвидности
+    Сигналы читаем из колонок BOS/CHOCH, ретесты ищем в ордер-блоке.
+    SL/TP ставим за свингами/структурой (HighLow = ±1).
     """
     dbg = _dbg_init(debug_log_path)
 
@@ -123,13 +156,57 @@ def generate_entries_with_josh(
     if col_lvl is None:
         return []
 
-    # 4) подготовка утилит
+    # 4) ордер-блоки и FVG для подтверждения
+    price_cols = [c for c in ["open", "high", "low", "close", "volume"] if c in m1.columns]
+    if not price_cols:
+        return []
+    price_df = m1[price_cols].copy()
+    if "volume" not in price_df:
+        price_df["volume"] = 1.0
+
+    obs = smc.ob(price_df, sw, close_mitigation=False)
+    fvgs = smc.fvg(price_df)
+
+    col_ob = _col(obs, "OB")
+    col_ob_top = _col(obs, "Top")
+    col_ob_bottom = _col(obs, "Bottom")
+    col_ob_mitigated = _col(obs, "MitigatedIndex")
+
+    if col_ob is None or col_ob_top is None or col_ob_bottom is None:
+        return []
+
+    col_fvg = _col(fvgs, "FVG")
+    col_fvg_top = _col(fvgs, "Top")
+    col_fvg_bottom = _col(fvgs, "Bottom")
+    col_fvg_mitigated = _col(fvgs, "MitigatedIndex")
+
+    # 5) подготовка утилит
     base_times = df_ticks["time"].to_numpy()
     tol = float(retest_tolerance_pips) * float(pip)
+    max_retest_bars = max(1, int(max_retest_minutes))
 
-    def nearest_tick_idx(ts) -> int:
-        pos = np.searchsorted(base_times, pd.to_datetime(ts, utc=True))
-        return int(min(max(pos, 0), len(base_times) - 1))
+    def tick_range_for_minute(minute_idx: int) -> Tuple[int, int]:
+        start_ts = pd.to_datetime(m1.loc[minute_idx, "time"], utc=True)
+        if minute_idx + 1 < len(m1):
+            end_ts = pd.to_datetime(m1.loc[minute_idx + 1, "time"], utc=True)
+        else:
+            end_ts = start_ts + pd.Timedelta(minutes=1)
+        start = int(np.searchsorted(base_times, start_ts.to_datetime64()))
+        end = int(np.searchsorted(base_times, end_ts.to_datetime64(), side="left"))
+        if start >= len(base_times):
+            start = len(base_times) - 1
+        start = max(0, start)
+        end = max(start + 1, min(end if end > start else start + 1, len(base_times)))
+        return start, end
+
+    swing_high_list = sorted(swing_highs)
+    swing_low_list = sorted(swing_lows)
+
+    def next_swing(idx_list: List[int], current: int) -> Optional[int]:
+        pos = bisect_right(idx_list, current)
+        if pos < len(idx_list):
+            return idx_list[pos]
+        return None
 
     entries: List[Entry] = []
     last_H = last_L = None  # индексы последних свингов
@@ -140,85 +217,209 @@ def generate_entries_with_josh(
         if i in swing_lows:
             last_L = i
         if last_H is None or last_L is None:
-            # пока не знаем оба свинга — не можем ставить SL/TP «за свингом»
             continue
 
-        # Направление: сначала BOS, потом (по флагу) CHOCH
         dir_ = 0
-        lvl_i = None
 
         if use_bos and col_bos is not None:
             v = st.loc[i, col_bos]
             if pd.notna(v) and v != 0:
                 dir_ = +1 if v == 1 else -1
-                lvl_i = st.loc[i, col_lvl]
 
         if dir_ == 0 and (allow_choch_fallback or use_choch) and col_choch is not None:
             v = st.loc[i, col_choch]
             if pd.notna(v) and v != 0:
                 dir_ = +1 if v == 1 else -1
-                lvl_i = st.loc[i, col_lvl]
 
-        if dir_ == 0 or pd.isna(lvl_i):
-            _dbg_row(dbg, reason="skip_no_signal", i=i, entry_min_idx=None, dir=0,
-                     entry_time=m1.loc[i, "time"], hour=pd.to_datetime(m1.loc[i, "time"]).hour,
-                     level=None, tol_pips=retest_tolerance_pips, sl_pips=None, tp_pips=None)
+        if dir_ == 0:
+            _dbg_row(
+                dbg,
+                reason="skip_no_signal",
+                i=i,
+                entry_min_idx=None,
+                dir=0,
+                entry_time=m1.loc[i, "time"],
+                hour=pd.to_datetime(m1.loc[i, "time"]).hour,
+                level=None,
+                tol_pips=retest_tolerance_pips,
+                sl_pips=None,
+                tp_pips=None,
+            )
             continue
 
-        break_level = float(lvl_i)
+        ob_idx = None
+        ob_top = ob_bottom = None
 
-        # 5) ищем ПЕРВЫЙ ретест уровня в ближайшие 2000 минут после сигнала
+        if col_ob is not None:
+            for k in range(i, -1, -1):
+                ob_val = obs.loc[k, col_ob]
+                if pd.isna(ob_val) or int(ob_val) != dir_:
+                    continue
+                top_val = obs.loc[k, col_ob_top] if col_ob_top is not None else np.nan
+                bottom_val = obs.loc[k, col_ob_bottom] if col_ob_bottom is not None else np.nan
+                if pd.isna(top_val) or pd.isna(bottom_val):
+                    continue
+                mitigated_val = obs.loc[k, col_ob_mitigated] if col_ob_mitigated is not None else np.nan
+                if pd.isna(mitigated_val) or mitigated_val == 0 or mitigated_val > i:
+                    ob_idx = k
+                    ob_top = float(top_val)
+                    ob_bottom = float(bottom_val)
+                    break
+
+        if ob_idx is None:
+            _dbg_row(
+                dbg,
+                reason="skip_no_order_block",
+                i=i,
+                entry_min_idx=None,
+                dir=dir_,
+                entry_time=m1.loc[i, "time"],
+                hour=pd.to_datetime(m1.loc[i, "time"]).hour,
+                level=None,
+                tol_pips=retest_tolerance_pips,
+                sl_pips=None,
+                tp_pips=None,
+            )
+            continue
+
+        zone_low = min(ob_top, ob_bottom)
+        zone_high = max(ob_top, ob_bottom)
+
+        fvg_idx = None
+        if col_fvg is not None:
+            start_search = max(0, i - 5)
+            for k in range(i, start_search - 1, -1):
+                fvg_val = fvgs.loc[k, col_fvg]
+                if pd.isna(fvg_val) or int(fvg_val) != dir_:
+                    continue
+                mitigated_val = fvgs.loc[k, col_fvg_mitigated] if col_fvg_mitigated is not None else np.nan
+                if pd.isna(mitigated_val) or mitigated_val == 0 or mitigated_val > i:
+                    fvg_idx = k
+                    break
+        if require_fvg_confirmation and fvg_idx is None:
+            _dbg_row(
+                dbg,
+                reason="skip_no_fvg",
+                i=i,
+                entry_min_idx=None,
+                dir=dir_,
+                entry_time=m1.loc[i, "time"],
+                hour=pd.to_datetime(m1.loc[i, "time"]).hour,
+                level=None,
+                tol_pips=retest_tolerance_pips,
+                sl_pips=None,
+                tp_pips=None,
+                ob_idx=ob_idx,
+                ob_top=ob_top,
+                ob_bottom=ob_bottom,
+            )
+            continue
+
         entry_min_idx = None
-        for j in range(i + 1, min(i + 2000, len(m1))):
-            if dir_ == +1:
-                # лонг: ретест — low <= level + tol
-                if float(m1.loc[j, "low"]) <= break_level + tol:
-                    entry_min_idx = j
-                    break
-            else:
-                # шорт: ретест — high >= level - tol
-                if float(m1.loc[j, "high"]) >= break_level - tol:
-                    entry_min_idx = j
-                    break
+        for j in range(i + 1, min(i + 1 + max_retest_bars, len(m1))):
+            high_j = float(m1.loc[j, "high"])
+            low_j = float(m1.loc[j, "low"])
+            intersects = (high_j >= zone_low - tol) and (low_j <= zone_high + tol)
+            if intersects:
+                entry_min_idx = j
+                break
 
         if entry_min_idx is None:
-            _dbg_row(dbg, reason="skip_no_retest", i=i, entry_min_idx=None, dir=dir_,
-                     entry_time=m1.loc[i, "time"], hour=pd.to_datetime(m1.loc[i, "time"]).hour,
-                     level=break_level, tol_pips=retest_tolerance_pips, sl_pips=None, tp_pips=None)
+            _dbg_row(
+                dbg,
+                reason="skip_no_retest",
+                i=i,
+                entry_min_idx=None,
+                dir=dir_,
+                entry_time=m1.loc[i, "time"],
+                hour=pd.to_datetime(m1.loc[i, "time"]).hour,
+                level=None,
+                tol_pips=retest_tolerance_pips,
+                sl_pips=None,
+                tp_pips=None,
+                ob_idx=ob_idx,
+                fvg_idx=fvg_idx,
+                ob_top=ob_top,
+                ob_bottom=ob_bottom,
+            )
             continue
 
-        # 6) Формируем сделку: вход — первый тик на минуте ретеста
+        tick_start, tick_end = tick_range_for_minute(entry_min_idx)
+        chosen_tick = tick_start
+        for idx in range(tick_start, tick_end):
+            bid_price = df_ticks.iloc[idx]["bid"]
+            ask_price = df_ticks.iloc[idx]["ask"]
+            if dir_ == +1 and ask_price <= zone_high + tol:
+                chosen_tick = idx
+                break
+            if dir_ == -1 and bid_price >= zone_low - tol:
+                chosen_tick = idx
+                break
+
         entry_time = m1.loc[entry_min_idx, "time"]
-        eidx = nearest_tick_idx(entry_time)
+        entry_price = float(df_ticks.iloc[chosen_tick]["ask"] if dir_ == +1 else df_ticks.iloc[chosen_tick]["bid"])
 
         if dir_ == +1:
-            # лонг: SL за последним swing low; TP за последним swing high
-            protect = float(m1.loc[last_L, "low"])
-            target  = float(m1.loc[last_H, "high"])
-            entry_price = float(df_ticks.iloc[eidx]["ask"])
-            stop_price  = protect - sl_margin_pips * pip
-            tp_price    = target  + tp_margin_pips * pip
-            stop_pips   = max(0.0, (entry_price - stop_price) / pip)
-            tp_pips     = max(0.0, (tp_price - entry_price) / pip)
+            swing_stop = float(m1.loc[last_L, "low"])
+            stop_level = min(swing_stop, zone_low)
+            stop_price = stop_level - sl_margin_pips * pip
+            next_target_idx = next_swing(swing_high_list, i)
+            if next_target_idx is None:
+                next_target_idx = last_H
+            target_level = float(m1.loc[next_target_idx, "high"])
+            tp_base = max(target_level, entry_price)
+            tp_price = max(entry_price, tp_base + tp_margin_pips * pip)
+            stop_pips = max(0.0, (entry_price - stop_price) / pip)
+            tp_pips = max(0.0, (tp_price - entry_price) / pip)
         else:
-            # шорт: SL за последним swing high; TP за последним swing low
-            protect = float(m1.loc[last_H, "high"])
-            target  = float(m1.loc[last_L, "low"])
-            entry_price = float(df_ticks.iloc[eidx]["bid"])
-            stop_price  = protect + sl_margin_pips * pip
-            tp_price    = target  - tp_margin_pips * pip
-            stop_pips   = max(0.0, (stop_price - entry_price) / pip)
-            tp_pips     = max(0.0, (entry_price - tp_price) / pip)
+            swing_stop = float(m1.loc[last_H, "high"])
+            stop_level = max(swing_stop, zone_high)
+            stop_price = stop_level + sl_margin_pips * pip
+            next_target_idx = next_swing(swing_low_list, i)
+            if next_target_idx is None:
+                next_target_idx = last_L
+            target_level = float(m1.loc[next_target_idx, "low"])
+            tp_base = min(target_level, entry_price)
+            tp_price = min(entry_price, tp_base - tp_margin_pips * pip)
+            stop_pips = max(0.0, (stop_price - entry_price) / pip)
+            tp_pips = max(0.0, (entry_price - tp_price) / pip)
 
-        _dbg_row(dbg, reason="accepted", i=i, entry_min_idx=entry_min_idx, dir=dir_,
-                 entry_time=entry_time, hour=pd.to_datetime(entry_time).hour,
-                 level=break_level, tol_pips=retest_tolerance_pips,
-                 sl_pips=round(stop_pips, 6), tp_pips=round(tp_pips, 6))
+        _dbg_row(
+            dbg,
+            reason="accepted",
+            i=i,
+            entry_min_idx=entry_min_idx,
+            dir=dir_,
+            entry_time=entry_time,
+            hour=pd.to_datetime(entry_time).hour,
+            level=None,
+            tol_pips=retest_tolerance_pips,
+            sl_pips=round(stop_pips, 6),
+            tp_pips=round(tp_pips, 6),
+            ob_idx=ob_idx,
+            fvg_idx=fvg_idx,
+            ob_top=ob_top,
+            ob_bottom=ob_bottom,
+            target_level=target_level,
+        )
 
-        entries.append((
-            eidx, int(dir_), float(stop_pips), float(tp_pips),
-            float(stop_price), float(tp_price),
-            {"i": i, "entry_min_idx": entry_min_idx, "source": "smc.bos_choch"}
-        ))
+        entries.append(
+            (
+                int(chosen_tick),
+                int(dir_),
+                float(stop_pips),
+                float(tp_pips),
+                float(stop_price),
+                float(tp_price),
+                {
+                    "i": i,
+                    "entry_min_idx": entry_min_idx,
+                    "source": "smc.bos_choch",
+                    "ob_idx": ob_idx,
+                    "fvg_idx": fvg_idx,
+                    "target_level": target_level,
+                },
+            )
+        )
 
     return entries


### PR DESCRIPTION
## Summary
- enrich the tick-to-minute adapter with volume data, order-block targeting and fair-value-gap confirmation to drive more human-like entries
- expand the debug output and trade metadata so SMC decisions capture order-block and liquidity context
- expose CLI switches for the new retest window and FVG confirmation logic and document the updated entry flow

## Testing
- python -m compileall smc_adapter_josh.py one_pip_stop_sensitivity.py
- python one_pip_stop_sensitivity.py --help *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68e0557479b8832886a7410e3637bb9f